### PR TITLE
fix: run server directly in workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,12 +24,19 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: npm ci
-      - name: Build
+
+      - name: Build server
         run: npm run build
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
+
+      - name: Start server
+        run: npm run start &
+
       - name: Run Playwright tests
         run: npx playwright test
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -73,10 +73,10 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: "npm run start",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
-    timeout: 30 * 1000,
-  },
+  // webServer: {
+  //   command: "npm run start",
+  //   url: "http://localhost:3000",
+  //   reuseExistingServer: !process.env.CI,
+  //   timeout: 30 * 1000,
+  // },
 });


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Playwright tests. The change improves the build process by creating the build step 'Build server' instead of relying on the server made by the playwright.
---

