### PR TITLE
fix: change tsconfig.node

### DIFF
--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -38,7 +38,7 @@ export default async function Page() {
             <div className=" h-full items-stretch justify-center min-h-[content] px-6 sm:px-4 pt-0">
                 <div className="flex-1 grow flex">
                     <Suspense fallback={<GreetingsShimmer />}>
-                        {/* @ts-expect-error Server Component */}
+                        {/* @ts-ignore */}
                         <Greetings />
                     </Suspense>
                 </div>
@@ -56,7 +56,7 @@ export default async function Page() {
                 </div>
                 <div className="mt-6 flex-2 grow w-full flex">
                     <div className="w-full">
-                        {/* @ts-expect-error Server Component */}
+                        {/* @ts-ignore */}
                         <TaskCard projects={projects} />
                     </div>
                 </div>

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,8 +5,14 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "paths": {
-      "@/*": ["./*"]
-    }
+        "@/components/*": ["./components/*"],
+        "@/hooks/*": ["./hooks/*"],
+        "@/utilities/*": ["./utilities/*"],
+        "@/styles/*": ["./styles/*"],
+        "@/prisma/*": ["./prisma/*"],
+        "@/assets/*": ["./assets/*"]
+}
+
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
### TL;DR
Updated the TypeScript configuration paths in `tsconfig.node.json` and removed `@ts-expect-error` comments from the home page components.

### What changed?
1. Changed `@ts-expect-error Server Component` to `@ts-ignore` comments in `app/(dashboard)/home/page.tsx`.
2. Updated the paths in `tsconfig.node.json` to include paths for `components`, `hooks`, `utilities`, `styles`, `prisma`, and `assets`.
